### PR TITLE
Public API の作成

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -227,6 +227,8 @@ type PermissionManager interface {
     // 個人権限管理
     AddPlayerPermission(playerID uuid.UUID, permission string) error
     RemovePlayerPermission(playerID uuid.UUID, permission string) error
+    SetPlayerPermissions(playerID uuid.UUID, permissions []string) error
+    GetPlayerPermissions(playerID uuid.UUID) []string
     
     // グループ権限管理
     AddPermissionToGroup(groupName, permission string) error
@@ -250,7 +252,7 @@ var (
 ```
 
 #### 公開APIの特徴
-- **10個のコアメソッド**: 権限管理に必要な機能を厳選
+- **12個のコアメソッド**: 権限管理に必要な機能を厳選
 - **エラー変換**: 内部エラーを6つの公開エラー型に変換
 - **安定したインターフェース**: 内部実装変更に影響されない
 - **キャッシュ対応**: 権限チェックの高速化
@@ -272,8 +274,6 @@ var (
 - `GetGroup(name string) *shared.Group`
 - `GetAllGroups() map[string]*shared.Group`
 - `GetPlayerGroups(playerID uuid.UUID) []string`
-- `SetPlayerPermissions(playerID uuid.UUID, permissions []string) error`
-- `GetPlayerPermissions(playerID uuid.UUID) []string`
 - `Reload() error`
 - `ClearCache()`
 - `SetCacheEnabled(enabled bool)`

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -219,6 +219,7 @@ type PermissionManager interface {
     // グループ管理
     CreateGroup(name string, permissions []string) error
     DeleteGroup(name string) error
+    UpdateGroup(name string, permissions []string) error
     
     // プレイヤー-グループ関係
     AddPlayerToGroup(playerID uuid.UUID, playerName, groupName string) error
@@ -252,7 +253,7 @@ var (
 ```
 
 #### 公開APIの特徴
-- **12個のコアメソッド**: 権限管理に必要な機能を厳選
+- **13個のコアメソッド**: 権限管理に必要な機能を厳選
 - **エラー変換**: 内部エラーを6つの公開エラー型に変換
 - **安定したインターフェース**: 内部実装変更に影響されない
 - **キャッシュ対応**: 権限チェックの高速化
@@ -270,7 +271,6 @@ var (
 - `PlayerExists(playerID uuid.UUID) bool`
 - `GetPlayerData(playerID uuid.UUID) *shared.PlayerData`
 - `GetAllPlayers() map[uuid.UUID]*shared.PlayerData`
-- `UpdateGroup(name string, permissions []string) error`
 - `GetGroup(name string) *shared.Group`
 - `GetAllGroups() map[string]*shared.Group`
 - `GetPlayerGroups(playerID uuid.UUID) []string`

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -32,20 +32,25 @@ Minecraft Bedrock Edition Dragonflyサーバー向けの包括的な権限管理
 - ✅ **Application層**: 統合管理機能（Manager）
 - ✅ **Shared**: 共通型定義と設定
 
+#### 公開API
+- ✅ **permission.go**: 公開APIエントリーポイント
+- ✅ **errors.go**: 公開エラー定義
+- ✅ **PermissionManager**: ラッパー方式インターフェース
+
 ### 🚧 未実装機能
 
-#### 公開API
-- ❌ **permission.go**: 公開APIエントリーポイント
+#### 高度な機能
 - ❌ **options.go**: オプションパターン実装
-- ❌ **errors.go**: 公開エラー定義
 - ❌ **QuickStart()**: 簡単セットアップ関数
 
 ## プロジェクト構造
 
-### 現在の実装済み構造
+### 実装済み構造
 ```
 df-permission/
-├── types.go                    # ✅ 公開データ型（ManagerConfig）
+├── permission.go               # ✅ 公開API（PermissionManagerインターフェース）
+├── errors.go                   # ✅ 公開エラー定義（6つのエラー型）
+├── types.go                    # ✅ 公開データ型（設定構造体の再エクスポート）
 ├── docs/
 │   └── SPECIFICATION.md        # ✅ 仕様書
 │
@@ -62,30 +67,25 @@ df-permission/
     ├── application/            # ✅ アプリケーション層
     │   └── manager.go          # ✅ 統合管理機能
     └── shared/                 # ✅ 共有定義
-        ├── types.go            # ✅ 共有データ型
-        └── config.go           # ✅ 設定構造体
+        ├── types.go            # ✅ 共有データ型（設定構造体含む）
 ```
 
-### 予定されている公開API構造
+### 未実装の拡張機能
 ```
 df-permission/
-├── permission.go      # ❌ 公開API（未実装）
 ├── options.go         # ❌ オプションパターン（未実装）
-├── errors.go          # ❌ 公開エラー定義（未実装）
-└── types.go           # ✅ 公開データ型（実装済み）
+└── quickstart.go      # ❌ 簡単セットアップ（未実装）
 ```
 
 ## 使用例
 
-### 現在の実装での使用方法
+### 公開API使用方法（推奨）
 ```go
 package main
 
 import (
     "github.com/google/uuid"
-    dfpermission "github.com/skuralll/df-permission"
-    "github.com/skuralll/df-permission/internal/application"
-    "github.com/skuralll/df-permission/internal/shared"
+    "github.com/skuralll/df-permission"
     "time"
 )
 
@@ -93,55 +93,92 @@ func main() {
     // 1. 設定を作成
     config := dfpermission.ManagerConfig{
         AutoSave: true,
-        Storage: shared.StorageConfig{
+        Storage: dfpermission.StorageConfig{
             Path: "./permissions.json",
         },
-        Cache: shared.CacheConfig{
+        Cache: dfpermission.CacheConfig{
             Enabled:         true,
             TTL:             30 * time.Second,
             CleanupInterval: time.Minute,
         },
     }
     
-    // 2. マネージャーを作成
-    mgr := application.NewManager(config)
+    // 2. 公開APIでマネージャーを作成
+    mgr := dfpermission.NewManager(config)
     
     // 3. グループを作成
-    mgr.CreateGroup("vip", []string{"chat.color", "world.build.fast"})
-    mgr.CreateGroup("moderator", []string{"moderation.*"})
+    err := mgr.CreateGroup("vip", []string{"chat.color", "world.build.fast"})
+    if err != nil {
+        // エラーハンドリング（公開エラー型）
+        if err == dfpermission.ErrGroupAlreadyExists {
+            // グループが既に存在
+        }
+    }
     
     // 4. プレイヤーをグループに追加
     playerID := uuid.New()
-    mgr.AddPlayerToGroup(playerID, "Steve", "vip")
+    err = mgr.AddPlayerToGroup(playerID, "Steve", "vip")
+    if err != nil {
+        // エラーハンドリング
+    }
     
     // 5. 権限をチェック
     if mgr.HasPermission(playerID, "chat.color") {
         // プレイヤーはカラーチャットを使用可能
     }
     
-    if mgr.HasPermission(playerID, "moderation.kick") {
-        // プレイヤーは他のプレイヤーをキック可能（VIPでは false）
+    // 6. 個人権限を追加
+    err = mgr.AddPlayerPermission(playerID, "custom.permission")
+    if err == dfpermission.ErrPlayerNotFound {
+        // プレイヤーが存在しない
     }
     
-    // 6. データを手動保存
+    // 7. データを保存
     mgr.Save()
 }
 ```
 
-### 予定されている公開API
+### 内部API直接使用（開発・テスト用）
 ```go
 package main
 
 import (
     "github.com/google/uuid"
+    "github.com/skuralll/df-permission/internal/application"
+    "github.com/skuralll/df-permission/internal/shared"
+    "time"
+)
+
+func main() {
+    // 内部APIを直接使用（非推奨）
+    config := shared.ManagerConfig{
+        // 設定内容は同じ
+    }
+    mgr := application.NewManager(config)
+    // 全ての内部メソッドにアクセス可能
+}
+```
+
+### 未実装の拡張予定API
+```go
+package main
+
+import (
     "github.com/skuralll/df-permission"
 )
 
 func main() {
-    // 1. デフォルト設定でマネージャーを作成（未実装）
-    mgr := permission.QuickStart()
+    // 将来の拡張機能（未実装）
     
-    // 以下、現在の実装と同様のAPI...
+    // オプションパターン
+    mgr := dfpermission.NewManager(
+        dfpermission.WithStorage("./permissions.json"),
+        dfpermission.WithCache(30*time.Second),
+        dfpermission.WithAutoSave(true),
+    )
+    
+    // クイックスタート
+    mgr := dfpermission.QuickStart()
 }
 ```
 
@@ -154,48 +191,68 @@ func main() {
 - `prefix.*` : `prefix.`で始まる全ての権限を付与（プレフィックスワイルドカード）
 - `prefix.specific` : 特定の権限のみを付与
 
-### 実装済みAPI（internal/application/manager.go）
+### 公開API（permission.go）
 
-#### 権限チェック
-- `HasPermission(playerID uuid.UUID, permission string) bool`
-  - プレイヤーが特定の権限を持っているかチェック
-  - キャッシュされた結果を返す
+#### PermissionManagerインターフェース
+```go
+type PermissionManager interface {
+    // 権限チェック
+    HasPermission(playerID uuid.UUID, permission string) bool
+    
+    // グループ管理
+    CreateGroup(name string, permissions []string) error
+    DeleteGroup(name string) error
+    
+    // プレイヤー-グループ関係
+    AddPlayerToGroup(playerID uuid.UUID, playerName, groupName string) error
+    RemovePlayerFromGroup(playerID uuid.UUID, groupName string) error
+    
+    // 個人権限管理
+    AddPlayerPermission(playerID uuid.UUID, permission string) error
+    RemovePlayerPermission(playerID uuid.UUID, permission string) error
+    
+    // システム操作
+    Save() error
+}
+```
 
-#### プレイヤー管理
+#### 公開エラー型（errors.go）
+```go
+var (
+    ErrPlayerNotFound       = errors.New("player not found")
+    ErrGroupNotFound        = errors.New("group not found")
+    ErrGroupAlreadyExists   = errors.New("group already exists")
+    ErrSystemGroupProtected = errors.New("system group cannot be deleted")
+    ErrPlayerAlreadyExists  = errors.New("player already exists")
+    ErrPermissionNotFound   = errors.New("permission not found")
+)
+```
+
+#### ファクトリー関数
+- `NewManager(config ManagerConfig) PermissionManager`
+  - 設定からPermissionManagerを作成
+  - 内部実装をラップして安定したAPIを提供
+
+### 内部API（internal/application/manager.go）
+
+#### 拡張機能（公開APIでは利用不可）
 - `CreatePlayer(playerID uuid.UUID, playerName string) error`
 - `RemovePlayer(playerID uuid.UUID) error`
 - `PlayerExists(playerID uuid.UUID) bool`
 - `GetPlayerData(playerID uuid.UUID) *shared.PlayerData`
 - `GetAllPlayers() map[uuid.UUID]*shared.PlayerData`
-
-#### グループ管理
-- `CreateGroup(name string, permissions []string) error`
-- `DeleteGroup(name string) error`
 - `UpdateGroup(name string, permissions []string) error`
 - `GetGroup(name string) *shared.Group`
 - `GetAllGroups() map[string]*shared.Group`
-
-#### プレイヤー-グループ関係
-- `AddPlayerToGroup(playerID uuid.UUID, playerName, groupName string) error`
-- `RemovePlayerFromGroup(playerID uuid.UUID, groupName string) error`
 - `GetPlayerGroups(playerID uuid.UUID) []string`
-
-#### 個人権限管理
-- `AddPlayerPermission(playerID uuid.UUID, permission string) error`
-- `RemovePlayerPermission(playerID uuid.UUID, permission string) error`
 - `SetPlayerPermissions(playerID uuid.UUID, permissions []string) error`
 - `GetPlayerPermissions(playerID uuid.UUID) []string`
-
-#### グループ権限管理
 - `AddPermissionToGroup(groupName, permission string) error`
 - `RemovePermissionFromGroup(groupName, permission string) error`
-
-#### システム管理
-- `Save() error` - データを手動保存
-- `Reload() error` - データを再読み込み
-- `ClearCache()` - キャッシュをクリア
-- `SetCacheEnabled(enabled bool)` - キャッシュの有効/無効切り替え
-- `SetAutoSave(enabled bool)` - オートセーブの有効/無効切り替え
+- `Reload() error`
+- `ClearCache()`
+- `SetCacheEnabled(enabled bool)`
+- `SetAutoSave(enabled bool)`
 
 ### デフォルトグループ
 システム起動時に以下のデフォルトグループが作成されます：
@@ -237,24 +294,56 @@ type Group struct {
 #### ManagerConfig
 ```go
 type ManagerConfig struct {
-    AutoSave bool
-    Storage  shared.StorageConfig
-    Cache    shared.CacheConfig
+    AutoSave bool              // 変更時の自動保存
+    Storage  StorageConfig     // ストレージ設定
+    Cache    CacheConfig       // キャッシュ設定
 }
 ```
 
 #### StorageConfig
 ```go
 type StorageConfig struct {
-    Path string // JSONファイルのパス
+    Path string // JSONファイルのパス（例: "./permissions.json"）
 }
 ```
 
 #### CacheConfig
 ```go
 type CacheConfig struct {
-    TTL             time.Duration // キャッシュの有効期限
-    CleanupInterval time.Duration // クリーンアップ間隔
+    TTL             time.Duration // キャッシュの有効期限（例: 30*time.Second）
+    CleanupInterval time.Duration // クリーンアップ間隔（例: time.Minute）
     Enabled         bool          // キャッシュ有効/無効
 }
 ```
+
+## アーキテクチャ設計
+
+### レイヤード構造
+1. **公開API層**: `permission.go`, `errors.go`, `types.go`
+   - 安定したインターフェース
+   - エラー変換とハンドリング
+   - 型の再エクスポート
+
+2. **アプリケーション層**: `internal/application/`
+   - ビジネスロジックの統合
+   - トランザクション管理
+   - キャッシュ制御
+
+3. **ドメイン層**: `internal/domain/`
+   - 権限チェックロジック
+   - パターンマッチング
+   - キャッシュ機能
+
+4. **リポジトリ層**: `internal/repository/`
+   - データ永続化
+   - ストレージ抽象化
+
+5. **共有層**: `internal/shared/`
+   - 共通データ型
+   - 設定構造体
+
+### 設計原則
+- **依存性逆転**: 上位レイヤーが下位レイヤーのインターフェースに依存
+- **単一責任**: 各レイヤーが明確な責任を持つ
+- **開放閉鎖**: 拡張に開放、修正に閉鎖
+- **インターフェース分離**: 必要最小限のメソッドのみ公開

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -127,13 +127,30 @@ func main() {
         // プレイヤーはカラーチャットを使用可能
     }
     
-    // 6. 個人権限を追加
+    // 6. グループに権限を動的に追加
+    err = mgr.AddPermissionToGroup("vip", "world.teleport")
+    if err != nil {
+        // エラーハンドリング
+    }
+    
+    // 7. プレイヤーは新しい権限を自動的に取得
+    if mgr.HasPermission(playerID, "world.teleport") {
+        // VIPグループのプレイヤーはテレポート可能
+    }
+    
+    // 8. 個人権限を追加
     err = mgr.AddPlayerPermission(playerID, "custom.permission")
     if err == dfpermission.ErrPlayerNotFound {
         // プレイヤーが存在しない
     }
     
-    // 7. データを保存
+    // 9. グループから権限を削除
+    err = mgr.RemovePermissionFromGroup("vip", "world.build.fast")
+    if err == dfpermission.ErrPermissionNotFound {
+        // グループが権限を持っていない
+    }
+    
+    // 10. データを保存
     mgr.Save()
 }
 ```
@@ -211,6 +228,10 @@ type PermissionManager interface {
     AddPlayerPermission(playerID uuid.UUID, permission string) error
     RemovePlayerPermission(playerID uuid.UUID, permission string) error
     
+    // グループ権限管理
+    AddPermissionToGroup(groupName, permission string) error
+    RemovePermissionFromGroup(groupName, permission string) error
+    
     // システム操作
     Save() error
 }
@@ -227,6 +248,12 @@ var (
     ErrPermissionNotFound   = errors.New("permission not found")
 )
 ```
+
+#### 公開APIの特徴
+- **10個のコアメソッド**: 権限管理に必要な機能を厳選
+- **エラー変換**: 内部エラーを6つの公開エラー型に変換
+- **安定したインターフェース**: 内部実装変更に影響されない
+- **キャッシュ対応**: 権限チェックの高速化
 
 #### ファクトリー関数
 - `NewManager(config ManagerConfig) PermissionManager`
@@ -247,8 +274,6 @@ var (
 - `GetPlayerGroups(playerID uuid.UUID) []string`
 - `SetPlayerPermissions(playerID uuid.UUID, permissions []string) error`
 - `GetPlayerPermissions(playerID uuid.UUID) []string`
-- `AddPermissionToGroup(groupName, permission string) error`
-- `RemovePermissionFromGroup(groupName, permission string) error`
 - `Reload() error`
 - `ClearCache()`
 - `SetCacheEnabled(enabled bool)`

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,68 @@
+package dfpermission
+
+import (
+	"errors"
+	"strings"
+)
+
+// Public error definitions for the permission management system
+var (
+	// ErrPlayerNotFound is returned when a requested player does not exist
+	ErrPlayerNotFound = errors.New("player not found")
+
+	// ErrGroupNotFound is returned when a requested group does not exist
+	ErrGroupNotFound = errors.New("group not found")
+
+	// ErrGroupAlreadyExists is returned when trying to create a group that already exists
+	ErrGroupAlreadyExists = errors.New("group already exists")
+
+	// ErrSystemGroupProtected is returned when trying to delete a system group
+	ErrSystemGroupProtected = errors.New("system group cannot be deleted")
+
+	// ErrPlayerAlreadyExists is returned when trying to create a player that already exists
+	ErrPlayerAlreadyExists = errors.New("player already exists")
+
+	// ErrPermissionNotFound is returned when trying to remove a permission that doesn't exist
+	ErrPermissionNotFound = errors.New("permission not found")
+)
+
+// convertError converts internal errors to public API errors.
+// This provides a stable error interface and hides internal implementation details.
+func convertError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	errMsg := err.Error()
+
+	// Convert player-related errors
+	if strings.Contains(errMsg, "player") {
+		if strings.Contains(errMsg, "not found") {
+			return ErrPlayerNotFound
+		}
+		if strings.Contains(errMsg, "already exists") {
+			return ErrPlayerAlreadyExists
+		}
+	}
+
+	// Convert group-related errors
+	if strings.Contains(errMsg, "group") {
+		if strings.Contains(errMsg, "not found") || strings.Contains(errMsg, "does not exist") {
+			return ErrGroupNotFound
+		}
+		if strings.Contains(errMsg, "already exists") {
+			return ErrGroupAlreadyExists
+		}
+		if strings.Contains(errMsg, "cannot delete system group") || strings.Contains(errMsg, "system group") {
+			return ErrSystemGroupProtected
+		}
+	}
+
+	// Convert permission-related errors
+	if strings.Contains(errMsg, "permission") && strings.Contains(errMsg, "not") {
+		return ErrPermissionNotFound
+	}
+
+	// Return original error if no conversion is needed
+	return err
+}

--- a/errors.go
+++ b/errors.go
@@ -5,29 +5,28 @@ import (
 	"strings"
 )
 
-// Public error definitions for the permission management system
+// パーミッション管理システムの公開エラー定義
 var (
-	// ErrPlayerNotFound is returned when a requested player does not exist
+	// 存在しないプレイヤー参照時のエラー
 	ErrPlayerNotFound = errors.New("player not found")
 
-	// ErrGroupNotFound is returned when a requested group does not exist
+	// 存在しないグループ参照時のエラー
 	ErrGroupNotFound = errors.New("group not found")
 
-	// ErrGroupAlreadyExists is returned when trying to create a group that already exists
+	// 既存グループ作成時のエラー
 	ErrGroupAlreadyExists = errors.New("group already exists")
 
-	// ErrSystemGroupProtected is returned when trying to delete a system group
+	// システムグループ削除時のエラー
 	ErrSystemGroupProtected = errors.New("system group cannot be deleted")
 
-	// ErrPlayerAlreadyExists is returned when trying to create a player that already exists
+	// 既存プレイヤー作成時のエラー
 	ErrPlayerAlreadyExists = errors.New("player already exists")
 
-	// ErrPermissionNotFound is returned when trying to remove a permission that doesn't exist
+	// 存在しないパーミッション削除時のエラー
 	ErrPermissionNotFound = errors.New("permission not found")
 )
 
-// convertError converts internal errors to public API errors.
-// This provides a stable error interface and hides internal implementation details.
+// 内部エラーを公開APIエラーへ変換
 func convertError(err error) error {
 	if err == nil {
 		return nil
@@ -35,7 +34,7 @@ func convertError(err error) error {
 
 	errMsg := err.Error()
 
-	// Convert player-related errors
+	// プレイヤー関連エラー変換
 	if strings.Contains(errMsg, "player") {
 		if strings.Contains(errMsg, "not found") {
 			return ErrPlayerNotFound
@@ -45,7 +44,7 @@ func convertError(err error) error {
 		}
 	}
 
-	// Convert group-related errors
+	// グループ関連エラー変換
 	if strings.Contains(errMsg, "group") {
 		if strings.Contains(errMsg, "not found") || strings.Contains(errMsg, "does not exist") {
 			return ErrGroupNotFound
@@ -58,11 +57,11 @@ func convertError(err error) error {
 		}
 	}
 
-	// Convert permission-related errors
+	// パーミッション関連エラー変換
 	if strings.Contains(errMsg, "permission") && strings.Contains(errMsg, "not") {
 		return ErrPermissionNotFound
 	}
 
-	// Return original error if no conversion is needed
+	// 変換不要時は元のエラーを返却
 	return err
 }

--- a/internal/application/manager.go
+++ b/internal/application/manager.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	dfpermission "github.com/skuralll/df-permission"
 	"github.com/skuralll/df-permission/internal/domain"
 	"github.com/skuralll/df-permission/internal/shared"
 )
@@ -23,7 +22,7 @@ type Manager struct {
 	mutex   sync.RWMutex
 }
 
-func NewManager(config dfpermission.ManagerConfig) *Manager {
+func NewManager(config shared.ManagerConfig) *Manager {
 	storage := *domain.NewPermissionRepository(config.Storage)
 	cache := domain.NewPermissionCache(config.Cache)
 	checker := domain.NewPermissionChecker()

--- a/internal/application/manager_test.go
+++ b/internal/application/manager_test.go
@@ -6,16 +6,16 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	dfpermission "github.com/skuralll/df-permission"
+	"github.com/skuralll/df-permission/internal/shared"
 )
 
 func createTestManager() *Manager {
-	config := dfpermission.ManagerConfig{
+	config := shared.ManagerConfig{
 		AutoSave: false,
-		Storage: dfpermission.StorageConfig{
+		Storage: shared.StorageConfig{
 			Path: "/tmp/test_permissions.json",
 		},
-		Cache: dfpermission.CacheConfig{
+		Cache: shared.CacheConfig{
 			Enabled:         false,
 			TTL:             5 * time.Second,
 			CleanupInterval: 10 * time.Second,
@@ -270,12 +270,12 @@ func TestSystemGroupProtection(t *testing.T) {
 
 func TestCacheManagement(t *testing.T) {
 	defer cleanup()
-	config := dfpermission.ManagerConfig{
+	config := shared.ManagerConfig{
 		AutoSave: false,
-		Storage: dfpermission.StorageConfig{
+		Storage: shared.StorageConfig{
 			Path: "/tmp/test_permissions.json",
 		},
-		Cache: dfpermission.CacheConfig{
+		Cache: shared.CacheConfig{
 			Enabled:         true,
 			TTL:             5 * time.Second,
 			CleanupInterval: 10 * time.Second,

--- a/internal/domain/cache.go
+++ b/internal/domain/cache.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	dfpermission "github.com/skuralll/df-permission"
+	"github.com/skuralll/df-permission/internal/shared"
 )
 
 // 権限チェック結果をメモリに保存し、パフォーマンス向上を狙うためのキャッシュシステム
@@ -27,7 +27,7 @@ type cacheEntry struct {
 	createdAt time.Time
 }
 
-func NewPermissionCache(config dfpermission.CacheConfig) *PermissionCache {
+func NewPermissionCache(config shared.CacheConfig) *PermissionCache {
 	// デフォルト設定
 	if config.TTL == 0 {
 		config.TTL = 30 * time.Second

--- a/internal/domain/cache_test.go
+++ b/internal/domain/cache_test.go
@@ -5,11 +5,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	dfpermission "github.com/skuralll/df-permission"
+	"github.com/skuralll/df-permission/internal/shared"
 )
 
 func TestNewPermissionCache(t *testing.T) {
-	config := dfpermission.CacheConfig{
+	config := shared.CacheConfig{
 		TTL:             10 * time.Second,
 		CleanupInterval: 5 * time.Second,
 		Enabled:         true,
@@ -31,7 +31,7 @@ func TestNewPermissionCache(t *testing.T) {
 }
 
 func TestPermissionCache_SetAndGet(t *testing.T) {
-	config := dfpermission.CacheConfig{
+	config := shared.CacheConfig{
 		TTL:     30 * time.Second,
 		Enabled: true,
 	}
@@ -61,7 +61,7 @@ func TestPermissionCache_SetAndGet(t *testing.T) {
 }
 
 func TestPermissionCache_Disabled(t *testing.T) {
-	config := dfpermission.CacheConfig{
+	config := shared.CacheConfig{
 		Enabled: false,
 	}
 	cache := NewPermissionCache(config)
@@ -79,7 +79,7 @@ func TestPermissionCache_Disabled(t *testing.T) {
 }
 
 func TestPermissionCache_TTL(t *testing.T) {
-	config := dfpermission.CacheConfig{
+	config := shared.CacheConfig{
 		TTL:     100 * time.Millisecond,
 		Enabled: true,
 	}
@@ -107,7 +107,7 @@ func TestPermissionCache_TTL(t *testing.T) {
 }
 
 func TestPermissionCache_Clear(t *testing.T) {
-	config := dfpermission.CacheConfig{
+	config := shared.CacheConfig{
 		TTL:     30 * time.Second,
 		Enabled: true,
 	}
@@ -137,7 +137,7 @@ func TestPermissionCache_Clear(t *testing.T) {
 }
 
 func TestPermissionCache_InvalidatePlayer(t *testing.T) {
-	config := dfpermission.CacheConfig{
+	config := shared.CacheConfig{
 		TTL:     30 * time.Second,
 		Enabled: true,
 	}
@@ -175,7 +175,7 @@ func TestPermissionCache_InvalidatePlayer(t *testing.T) {
 }
 
 func TestPermissionCache_InvalidatePermission(t *testing.T) {
-	config := dfpermission.CacheConfig{
+	config := shared.CacheConfig{
 		TTL:     30 * time.Second,
 		Enabled: true,
 	}
@@ -213,7 +213,7 @@ func TestPermissionCache_InvalidatePermission(t *testing.T) {
 }
 
 func TestPermissionCache_EnabledState(t *testing.T) {
-	config := dfpermission.CacheConfig{
+	config := shared.CacheConfig{
 		TTL:     30 * time.Second,
 		Enabled: false,
 	}
@@ -237,7 +237,7 @@ func TestPermissionCache_EnabledState(t *testing.T) {
 }
 
 func TestPermissionCache_AutoCleanup(t *testing.T) {
-	config := dfpermission.CacheConfig{
+	config := shared.CacheConfig{
 		TTL:             50 * time.Millisecond,
 		CleanupInterval: 30 * time.Millisecond,
 		Enabled:         true,
@@ -275,7 +275,7 @@ func TestPermissionCache_AutoCleanup(t *testing.T) {
 }
 
 func TestPermissionCache_CleanupStops(t *testing.T) {
-	config := dfpermission.CacheConfig{
+	config := shared.CacheConfig{
 		TTL:             100 * time.Millisecond,
 		CleanupInterval: 20 * time.Millisecond,
 		Enabled:         true,
@@ -301,7 +301,7 @@ func TestPermissionCache_CleanupStops(t *testing.T) {
 }
 
 func TestPermissionCache_SetEnabledCleanup(t *testing.T) {
-	config := dfpermission.CacheConfig{
+	config := shared.CacheConfig{
 		TTL:             50 * time.Millisecond,
 		CleanupInterval: 25 * time.Millisecond,
 		Enabled:         false,

--- a/internal/domain/storage.go
+++ b/internal/domain/storage.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	dfpermission "github.com/skuralll/df-permission"
 	"github.com/skuralll/df-permission/internal/repository"
 	"github.com/skuralll/df-permission/internal/shared"
 )
@@ -10,7 +9,7 @@ type PermissionRepository struct {
 	storage repository.Storage
 }
 
-func NewPermissionRepository(config dfpermission.StorageConfig) *PermissionRepository {
+func NewPermissionRepository(config shared.StorageConfig) *PermissionRepository {
 	return &PermissionRepository{
 		storage: repository.NewJSONStorage(config),
 	}

--- a/internal/repository/json_storage.go
+++ b/internal/repository/json_storage.go
@@ -7,18 +7,17 @@ import (
 	"sync"
 	"time"
 
-	dfpermission "github.com/skuralll/df-permission"
 	"github.com/skuralll/df-permission/internal/shared"
 )
 
 type JSONStorage struct {
-	config dfpermission.StorageConfig
+	config shared.StorageConfig
 	mutex  sync.RWMutex
 }
 
 var _ Storage = (*JSONStorage)(nil)
 
-func NewJSONStorage(config dfpermission.StorageConfig) *JSONStorage {
+func NewJSONStorage(config shared.StorageConfig) *JSONStorage {
 	return &JSONStorage{
 		config: config,
 		mutex:  sync.RWMutex{},

--- a/internal/repository/json_storage_test.go
+++ b/internal/repository/json_storage_test.go
@@ -7,13 +7,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	dfpermission "github.com/skuralll/df-permission"
 	"github.com/skuralll/df-permission/internal/shared"
 )
 
 func TestJSONStorage_Exists(t *testing.T) {
 	tempDir := t.TempDir()
-	storage := NewJSONStorage(dfpermission.StorageConfig{
+	storage := NewJSONStorage(shared.StorageConfig{
 		Path: filepath.Join(tempDir, "test.json"),
 	})
 
@@ -36,7 +35,7 @@ func TestJSONStorage_Exists(t *testing.T) {
 
 func TestJSONStorage_Save_Load(t *testing.T) {
 	tempDir := t.TempDir()
-	storage := NewJSONStorage(dfpermission.StorageConfig{
+	storage := NewJSONStorage(shared.StorageConfig{
 		Path: filepath.Join(tempDir, "test.json"),
 	})
 
@@ -110,7 +109,7 @@ func TestJSONStorage_Save_Load(t *testing.T) {
 
 func TestJSONStorage_Load_NonExistentFile(t *testing.T) {
 	tempDir := t.TempDir()
-	storage := NewJSONStorage(dfpermission.StorageConfig{
+	storage := NewJSONStorage(shared.StorageConfig{
 		Path: filepath.Join(tempDir, "nonexistent.json"),
 	})
 

--- a/internal/shared/types.go
+++ b/internal/shared/types.go
@@ -37,3 +37,23 @@ type Metadata struct {
 	CreatedAt time.Time `json:"created_at"` // 権限データが作成された日時
 	UpdatedAt time.Time `json:"updated_at"` // 権限データが最後に更新された日時
 }
+
+// ストレージファイルの設定
+type StorageConfig struct {
+	// 保存するファイルのパス
+	Path string
+}
+
+// キャッシュの設定
+type CacheConfig struct {
+	TTL             time.Duration
+	CleanupInterval time.Duration
+	Enabled         bool
+}
+
+// PermissionServiceの設定
+type ManagerConfig struct {
+	AutoSave bool
+	Storage  StorageConfig
+	Cache    CacheConfig
+}

--- a/permission.go
+++ b/permission.go
@@ -14,6 +14,7 @@ type PermissionManager interface {
 	// グループ管理
 	CreateGroup(name string, permissions []string) error
 	DeleteGroup(name string) error
+	UpdateGroup(name string, permissions []string) error
 
 	// プレイヤーとグループの関係
 	AddPlayerToGroup(playerID uuid.UUID, playerName, groupName string) error
@@ -64,6 +65,13 @@ func (p *permissionManager) CreateGroup(name string, permissions []string) error
 // 存在しない場合やシステムグループの場合はエラー
 func (p *permissionManager) DeleteGroup(name string) error {
 	err := p.internal.DeleteGroup(name)
+	return convertError(err)
+}
+
+// グループの権限を更新（置き換え）
+// グループが存在しない場合はエラー
+func (p *permissionManager) UpdateGroup(name string, permissions []string) error {
+	err := p.internal.UpdateGroup(name, permissions)
 	return convertError(err)
 }
 

--- a/permission.go
+++ b/permission.go
@@ -22,6 +22,8 @@ type PermissionManager interface {
 	// 個別プレイヤー権限
 	AddPlayerPermission(playerID uuid.UUID, permission string) error
 	RemovePlayerPermission(playerID uuid.UUID, permission string) error
+	SetPlayerPermissions(playerID uuid.UUID, permissions []string) error
+	GetPlayerPermissions(playerID uuid.UUID) []string
 
 	// グループ権限管理
 	AddPermissionToGroup(groupName, permission string) error
@@ -105,6 +107,19 @@ func (p *permissionManager) AddPermissionToGroup(groupName, permission string) e
 func (p *permissionManager) RemovePermissionFromGroup(groupName, permission string) error {
 	err := p.internal.RemovePermissionFromGroup(groupName, permission)
 	return convertError(err)
+}
+
+// プレイヤーの全権限を設定（置き換え）
+// プレイヤーが存在しない場合はエラー
+func (p *permissionManager) SetPlayerPermissions(playerID uuid.UUID, permissions []string) error {
+	err := p.internal.SetPlayerPermissions(playerID, permissions)
+	return convertError(err)
+}
+
+// プレイヤーの全権限を取得（個人権限+グループ権限）
+// プレイヤーが存在しない場合は空のスライスを返す
+func (p *permissionManager) GetPlayerPermissions(playerID uuid.UUID) []string {
+	return p.internal.GetPlayerPermissions(playerID)
 }
 
 // 現在の権限データをストレージに保存

--- a/permission.go
+++ b/permission.go
@@ -5,35 +5,35 @@ import (
 	"github.com/skuralll/df-permission/internal/application"
 )
 
-// PermissionManager provides a public interface for permission management operations.
-// It wraps the internal manager implementation and exposes only essential methods.
+// PermissionManagerは、権限管理操作のための公開インターフェース
+// 内部マネージャのラップ、必要なメソッドのみ公開
 type PermissionManager interface {
-	// Permission checking
+	// 権限チェック
 	HasPermission(playerID uuid.UUID, permission string) bool
 
-	// Group management
+	// グループ管理
 	CreateGroup(name string, permissions []string) error
 	DeleteGroup(name string) error
 
-	// Player-group relationships
+	// プレイヤーとグループの関係
 	AddPlayerToGroup(playerID uuid.UUID, playerName, groupName string) error
 	RemovePlayerFromGroup(playerID uuid.UUID, groupName string) error
 
-	// Individual player permissions
+	// 個別プレイヤー権限
 	AddPlayerPermission(playerID uuid.UUID, permission string) error
 	RemovePlayerPermission(playerID uuid.UUID, permission string) error
 
-	// System operations
+	// システム操作
 	Save() error
 }
 
-// permissionManager is the concrete implementation that wraps internal.Manager
+// permissionManagerは、internal.Managerの具体的実装
 type permissionManager struct {
 	internal *application.Manager
 }
 
-// NewManager creates a new PermissionManager with the given configuration.
-// It wraps the internal manager and provides a stable public API.
+// NewManagerは、指定された設定でPermissionManagerを作成
+// 内部マネージャをラップし、安定した公開APIを提供
 func NewManager(config ManagerConfig) PermissionManager {
 	internalMgr := application.NewManager(config)
 	return &permissionManager{
@@ -41,55 +41,55 @@ func NewManager(config ManagerConfig) PermissionManager {
 	}
 }
 
-// HasPermission checks if a player has a specific permission.
-// Returns true if the player has the permission either directly or through group membership.
+// HasPermissionは、プレイヤーが特定の権限を持つか確認
+// 直接またはグループ経由で権限を持つ場合true
 func (p *permissionManager) HasPermission(playerID uuid.UUID, permission string) bool {
 	return p.internal.HasPermission(playerID, permission)
 }
 
-// CreateGroup creates a new permission group with the specified permissions.
-// Returns an error if the group already exists.
+// CreateGroupは、指定した権限で新しいグループを作成
+// 既存の場合はエラー
 func (p *permissionManager) CreateGroup(name string, permissions []string) error {
 	err := p.internal.CreateGroup(name, permissions)
 	return convertError(err)
 }
 
-// DeleteGroup removes a permission group.
-// Returns an error if the group doesn't exist or is a system group.
+// DeleteGroupは、権限グループを削除
+// 存在しない場合やシステムグループの場合はエラー
 func (p *permissionManager) DeleteGroup(name string) error {
 	err := p.internal.DeleteGroup(name)
 	return convertError(err)
 }
 
-// AddPlayerToGroup adds a player to a permission group.
-// Creates the player if they don't exist.
+// AddPlayerToGroupは、プレイヤーをグループに追加
+// 存在しない場合はプレイヤーを作成
 func (p *permissionManager) AddPlayerToGroup(playerID uuid.UUID, playerName, groupName string) error {
 	err := p.internal.AddPlayerToGroup(playerID, playerName, groupName)
 	return convertError(err)
 }
 
-// RemovePlayerFromGroup removes a player from a permission group.
-// Returns an error if the player is not in the group.
+// RemovePlayerFromGroupは、プレイヤーをグループから削除
+// グループにいない場合はエラー
 func (p *permissionManager) RemovePlayerFromGroup(playerID uuid.UUID, groupName string) error {
 	err := p.internal.RemovePlayerFromGroup(playerID, groupName)
 	return convertError(err)
 }
 
-// AddPlayerPermission grants a specific permission directly to a player.
-// Returns an error if the player doesn't exist.
+// AddPlayerPermissionは、プレイヤーに直接権限を付与
+// プレイヤーが存在しない場合はエラー
 func (p *permissionManager) AddPlayerPermission(playerID uuid.UUID, permission string) error {
 	err := p.internal.AddPlayerPermission(playerID, permission)
 	return convertError(err)
 }
 
-// RemovePlayerPermission removes a specific permission from a player.
-// Returns an error if the player doesn't have the permission.
+// RemovePlayerPermissionは、プレイヤーから権限を削除
+// 権限を持っていない場合はエラー
 func (p *permissionManager) RemovePlayerPermission(playerID uuid.UUID, permission string) error {
 	err := p.internal.RemovePlayerPermission(playerID, permission)
 	return convertError(err)
 }
 
-// Save persists the current permission data to storage.
+// Saveは、現在の権限データをストレージに保存
 func (p *permissionManager) Save() error {
 	err := p.internal.Save()
 	return convertError(err)

--- a/permission.go
+++ b/permission.go
@@ -1,0 +1,96 @@
+package dfpermission
+
+import (
+	"github.com/google/uuid"
+	"github.com/skuralll/df-permission/internal/application"
+)
+
+// PermissionManager provides a public interface for permission management operations.
+// It wraps the internal manager implementation and exposes only essential methods.
+type PermissionManager interface {
+	// Permission checking
+	HasPermission(playerID uuid.UUID, permission string) bool
+
+	// Group management
+	CreateGroup(name string, permissions []string) error
+	DeleteGroup(name string) error
+
+	// Player-group relationships
+	AddPlayerToGroup(playerID uuid.UUID, playerName, groupName string) error
+	RemovePlayerFromGroup(playerID uuid.UUID, groupName string) error
+
+	// Individual player permissions
+	AddPlayerPermission(playerID uuid.UUID, permission string) error
+	RemovePlayerPermission(playerID uuid.UUID, permission string) error
+
+	// System operations
+	Save() error
+}
+
+// permissionManager is the concrete implementation that wraps internal.Manager
+type permissionManager struct {
+	internal *application.Manager
+}
+
+// NewManager creates a new PermissionManager with the given configuration.
+// It wraps the internal manager and provides a stable public API.
+func NewManager(config ManagerConfig) PermissionManager {
+	internalMgr := application.NewManager(config)
+	return &permissionManager{
+		internal: internalMgr,
+	}
+}
+
+// HasPermission checks if a player has a specific permission.
+// Returns true if the player has the permission either directly or through group membership.
+func (p *permissionManager) HasPermission(playerID uuid.UUID, permission string) bool {
+	return p.internal.HasPermission(playerID, permission)
+}
+
+// CreateGroup creates a new permission group with the specified permissions.
+// Returns an error if the group already exists.
+func (p *permissionManager) CreateGroup(name string, permissions []string) error {
+	err := p.internal.CreateGroup(name, permissions)
+	return convertError(err)
+}
+
+// DeleteGroup removes a permission group.
+// Returns an error if the group doesn't exist or is a system group.
+func (p *permissionManager) DeleteGroup(name string) error {
+	err := p.internal.DeleteGroup(name)
+	return convertError(err)
+}
+
+// AddPlayerToGroup adds a player to a permission group.
+// Creates the player if they don't exist.
+func (p *permissionManager) AddPlayerToGroup(playerID uuid.UUID, playerName, groupName string) error {
+	err := p.internal.AddPlayerToGroup(playerID, playerName, groupName)
+	return convertError(err)
+}
+
+// RemovePlayerFromGroup removes a player from a permission group.
+// Returns an error if the player is not in the group.
+func (p *permissionManager) RemovePlayerFromGroup(playerID uuid.UUID, groupName string) error {
+	err := p.internal.RemovePlayerFromGroup(playerID, groupName)
+	return convertError(err)
+}
+
+// AddPlayerPermission grants a specific permission directly to a player.
+// Returns an error if the player doesn't exist.
+func (p *permissionManager) AddPlayerPermission(playerID uuid.UUID, permission string) error {
+	err := p.internal.AddPlayerPermission(playerID, permission)
+	return convertError(err)
+}
+
+// RemovePlayerPermission removes a specific permission from a player.
+// Returns an error if the player doesn't have the permission.
+func (p *permissionManager) RemovePlayerPermission(playerID uuid.UUID, permission string) error {
+	err := p.internal.RemovePlayerPermission(playerID, permission)
+	return convertError(err)
+}
+
+// Save persists the current permission data to storage.
+func (p *permissionManager) Save() error {
+	err := p.internal.Save()
+	return convertError(err)
+}

--- a/permission.go
+++ b/permission.go
@@ -23,6 +23,10 @@ type PermissionManager interface {
 	AddPlayerPermission(playerID uuid.UUID, permission string) error
 	RemovePlayerPermission(playerID uuid.UUID, permission string) error
 
+	// グループ権限管理
+	AddPermissionToGroup(groupName, permission string) error
+	RemovePermissionFromGroup(groupName, permission string) error
+
 	// システム操作
 	Save() error
 }
@@ -86,6 +90,20 @@ func (p *permissionManager) AddPlayerPermission(playerID uuid.UUID, permission s
 // 権限を持っていない場合はエラー
 func (p *permissionManager) RemovePlayerPermission(playerID uuid.UUID, permission string) error {
 	err := p.internal.RemovePlayerPermission(playerID, permission)
+	return convertError(err)
+}
+
+// AddPermissionToGroupは、グループに権限を追加
+// グループが存在しない場合はエラー
+func (p *permissionManager) AddPermissionToGroup(groupName, permission string) error {
+	err := p.internal.AddPermissionToGroup(groupName, permission)
+	return convertError(err)
+}
+
+// RemovePermissionFromGroupは、グループから権限を削除
+// 権限を持っていない場合はエラー
+func (p *permissionManager) RemovePermissionFromGroup(groupName, permission string) error {
+	err := p.internal.RemovePermissionFromGroup(groupName, permission)
 	return convertError(err)
 }
 

--- a/permission.go
+++ b/permission.go
@@ -5,7 +5,7 @@ import (
 	"github.com/skuralll/df-permission/internal/application"
 )
 
-// PermissionManagerは、権限管理操作のための公開インターフェース
+// 権限管理操作のための公開インターフェース
 // 内部マネージャのラップ、必要なメソッドのみ公開
 type PermissionManager interface {
 	// 権限チェック
@@ -31,12 +31,12 @@ type PermissionManager interface {
 	Save() error
 }
 
-// permissionManagerは、internal.Managerの具体的実装
+// internal.Managerの具体的実装
 type permissionManager struct {
 	internal *application.Manager
 }
 
-// NewManagerは、指定された設定でPermissionManagerを作成
+// 指定された設定でPermissionManagerを作成
 // 内部マネージャをラップし、安定した公開APIを提供
 func NewManager(config ManagerConfig) PermissionManager {
 	internalMgr := application.NewManager(config)
@@ -45,69 +45,69 @@ func NewManager(config ManagerConfig) PermissionManager {
 	}
 }
 
-// HasPermissionは、プレイヤーが特定の権限を持つか確認
+// プレイヤーが特定の権限を持つか確認
 // 直接またはグループ経由で権限を持つ場合true
 func (p *permissionManager) HasPermission(playerID uuid.UUID, permission string) bool {
 	return p.internal.HasPermission(playerID, permission)
 }
 
-// CreateGroupは、指定した権限で新しいグループを作成
+// 指定した権限で新しいグループを作成
 // 既存の場合はエラー
 func (p *permissionManager) CreateGroup(name string, permissions []string) error {
 	err := p.internal.CreateGroup(name, permissions)
 	return convertError(err)
 }
 
-// DeleteGroupは、権限グループを削除
+// 権限グループを削除
 // 存在しない場合やシステムグループの場合はエラー
 func (p *permissionManager) DeleteGroup(name string) error {
 	err := p.internal.DeleteGroup(name)
 	return convertError(err)
 }
 
-// AddPlayerToGroupは、プレイヤーをグループに追加
+// プレイヤーをグループに追加
 // 存在しない場合はプレイヤーを作成
 func (p *permissionManager) AddPlayerToGroup(playerID uuid.UUID, playerName, groupName string) error {
 	err := p.internal.AddPlayerToGroup(playerID, playerName, groupName)
 	return convertError(err)
 }
 
-// RemovePlayerFromGroupは、プレイヤーをグループから削除
+// プレイヤーをグループから削除
 // グループにいない場合はエラー
 func (p *permissionManager) RemovePlayerFromGroup(playerID uuid.UUID, groupName string) error {
 	err := p.internal.RemovePlayerFromGroup(playerID, groupName)
 	return convertError(err)
 }
 
-// AddPlayerPermissionは、プレイヤーに直接権限を付与
+// プレイヤーに直接権限を付与
 // プレイヤーが存在しない場合はエラー
 func (p *permissionManager) AddPlayerPermission(playerID uuid.UUID, permission string) error {
 	err := p.internal.AddPlayerPermission(playerID, permission)
 	return convertError(err)
 }
 
-// RemovePlayerPermissionは、プレイヤーから権限を削除
+// プレイヤーから権限を削除
 // 権限を持っていない場合はエラー
 func (p *permissionManager) RemovePlayerPermission(playerID uuid.UUID, permission string) error {
 	err := p.internal.RemovePlayerPermission(playerID, permission)
 	return convertError(err)
 }
 
-// AddPermissionToGroupは、グループに権限を追加
+// グループに権限を追加
 // グループが存在しない場合はエラー
 func (p *permissionManager) AddPermissionToGroup(groupName, permission string) error {
 	err := p.internal.AddPermissionToGroup(groupName, permission)
 	return convertError(err)
 }
 
-// RemovePermissionFromGroupは、グループから権限を削除
+// グループから権限を削除
 // 権限を持っていない場合はエラー
 func (p *permissionManager) RemovePermissionFromGroup(groupName, permission string) error {
 	err := p.internal.RemovePermissionFromGroup(groupName, permission)
 	return convertError(err)
 }
 
-// Saveは、現在の権限データをストレージに保存
+// 現在の権限データをストレージに保存
 func (p *permissionManager) Save() error {
 	err := p.internal.Save()
 	return convertError(err)

--- a/permission_test.go
+++ b/permission_test.go
@@ -246,6 +246,105 @@ func TestPermissionManager_GroupPermissionManagement(t *testing.T) {
 	}
 }
 
+func TestPermissionManager_SetGetPlayerPermissions(t *testing.T) {
+	defer cleanupPublicTest()
+	mgr := createTestPermissionManager()
+	playerID := uuid.New()
+
+	// Add player to ensure they exist
+	err := mgr.AddPlayerToGroup(playerID, "TestPlayer", "default")
+	if err != nil {
+		t.Fatalf("Failed to add player to default group: %v", err)
+	}
+
+	// Initially, player should have default group permissions
+	permissions := mgr.GetPlayerPermissions(playerID)
+	if len(permissions) == 0 {
+		t.Error("Player in default group should have some permissions")
+	}
+
+	// Set multiple permissions
+	testPermissions := []string{"custom.permission1", "custom.permission2", "admin.special"}
+	err = mgr.SetPlayerPermissions(playerID, testPermissions)
+	if err != nil {
+		t.Fatalf("Failed to set player permissions: %v", err)
+	}
+
+	// Get permissions and verify (should include both individual and group permissions)
+	permissions = mgr.GetPlayerPermissions(playerID)
+	if len(permissions) < len(testPermissions) {
+		t.Errorf("Should have at least %d permissions, got %d", len(testPermissions), len(permissions))
+	}
+
+	// Check each permission exists
+	permMap := make(map[string]bool)
+	for _, perm := range permissions {
+		permMap[perm] = true
+	}
+	for _, expected := range testPermissions {
+		if !permMap[expected] {
+			t.Errorf("Expected permission %s not found in player permissions", expected)
+		}
+		// Also verify with HasPermission
+		if !mgr.HasPermission(playerID, expected) {
+			t.Errorf("Player should have permission %s", expected)
+		}
+	}
+
+	// Replace permissions with new set
+	newPermissions := []string{"new.permission1", "new.permission2"}
+	err = mgr.SetPlayerPermissions(playerID, newPermissions)
+	if err != nil {
+		t.Fatalf("Failed to replace player permissions: %v", err)
+	}
+
+	// Verify new permissions exist (should include both individual and group permissions)
+	permissions = mgr.GetPlayerPermissions(playerID)
+	if len(permissions) < len(newPermissions) {
+		t.Errorf("Should have at least %d permissions after replacement, got %d", len(newPermissions), len(permissions))
+	}
+
+	// Check old permissions are gone
+	for _, oldPerm := range testPermissions {
+		if mgr.HasPermission(playerID, oldPerm) {
+			t.Errorf("Player should not have old permission %s after replacement", oldPerm)
+		}
+	}
+
+	// Check new permissions exist
+	for _, newPerm := range newPermissions {
+		if !mgr.HasPermission(playerID, newPerm) {
+			t.Errorf("Player should have new permission %s", newPerm)
+		}
+	}
+
+	// Clear all permissions
+	err = mgr.SetPlayerPermissions(playerID, []string{})
+	if err != nil {
+		t.Fatalf("Failed to clear player permissions: %v", err)
+	}
+
+	permissions = mgr.GetPlayerPermissions(playerID)
+	// Should still have group permissions, but no individual permissions
+	groupPermissionsCount := len(permissions)
+	if groupPermissionsCount == 0 {
+		t.Error("Player should still have group permissions after clearing individual permissions")
+	}
+
+	// Try to set permissions for non-existent player
+	nonExistentID := uuid.New()
+	err = mgr.SetPlayerPermissions(nonExistentID, []string{"some.permission"})
+	if err != ErrPlayerNotFound {
+		t.Errorf("Expected ErrPlayerNotFound for non-existent player, got %v", err)
+	}
+
+	// GetPlayerPermissions should return empty slice for non-existent player
+	permissions = mgr.GetPlayerPermissions(nonExistentID)
+	if len(permissions) != 0 {
+		t.Errorf("Non-existent player should have empty permissions, got %v", permissions)
+	}
+}
+
 func TestPermissionManager_Save(t *testing.T) {
 	defer cleanupPublicTest()
 	mgr := createTestPermissionManager()

--- a/permission_test.go
+++ b/permission_test.go
@@ -1,0 +1,201 @@
+package dfpermission
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func createTestPermissionManager() PermissionManager {
+	config := ManagerConfig{
+		AutoSave: false,
+		Storage: StorageConfig{
+			Path: "/tmp/test_permission_public.json",
+		},
+		Cache: CacheConfig{
+			Enabled:         false,
+			TTL:             5 * time.Second,
+			CleanupInterval: 10 * time.Second,
+		},
+	}
+	return NewManager(config)
+}
+
+func cleanupPublicTest() {
+	os.Remove("/tmp/test_permission_public.json")
+}
+
+func TestPermissionManager_Interface(t *testing.T) {
+	defer cleanupPublicTest()
+	mgr := createTestPermissionManager()
+
+	if mgr == nil {
+		t.Fatal("PermissionManager creation failed")
+	}
+}
+
+func TestPermissionManager_HasPermission(t *testing.T) {
+	defer cleanupPublicTest()
+	mgr := createTestPermissionManager()
+	playerID := uuid.New()
+
+	// Non-existent player should not have permissions
+	if mgr.HasPermission(playerID, "any.permission") {
+		t.Error("Non-existent player should not have any permissions")
+	}
+
+	// Add player to admin group and test
+	err := mgr.AddPlayerToGroup(playerID, "TestPlayer", "admin")
+	if err != nil {
+		t.Fatalf("Failed to add player to admin group: %v", err)
+	}
+
+	if !mgr.HasPermission(playerID, "any.permission") {
+		t.Error("Admin should have all permissions")
+	}
+}
+
+func TestPermissionManager_GroupManagement(t *testing.T) {
+	defer cleanupPublicTest()
+	mgr := createTestPermissionManager()
+
+	// Create a new group
+	err := mgr.CreateGroup("vip", []string{"chat.color", "world.build.fast"})
+	if err != nil {
+		t.Fatalf("Failed to create group: %v", err)
+	}
+
+	// Try to create duplicate group
+	err = mgr.CreateGroup("vip", []string{})
+	if err != ErrGroupAlreadyExists {
+		t.Errorf("Expected ErrGroupAlreadyExists, got %v", err)
+	}
+
+	// Delete the group
+	err = mgr.DeleteGroup("vip")
+	if err != nil {
+		t.Fatalf("Failed to delete group: %v", err)
+	}
+
+	// Try to delete system group
+	err = mgr.DeleteGroup("admin")
+	if err != ErrSystemGroupProtected {
+		t.Errorf("Expected ErrSystemGroupProtected, got %v", err)
+	}
+}
+
+func TestPermissionManager_PlayerGroupMembership(t *testing.T) {
+	defer cleanupPublicTest()
+	mgr := createTestPermissionManager()
+	playerID := uuid.New()
+
+	// Create a test group
+	err := mgr.CreateGroup("vip", []string{"chat.color"})
+	if err != nil {
+		t.Fatalf("Failed to create group: %v", err)
+	}
+
+	// Add player to group
+	err = mgr.AddPlayerToGroup(playerID, "TestPlayer", "vip")
+	if err != nil {
+		t.Fatalf("Failed to add player to group: %v", err)
+	}
+
+	// Check permission from group
+	if !mgr.HasPermission(playerID, "chat.color") {
+		t.Error("Player should inherit permission from group")
+	}
+
+	// Remove player from group
+	err = mgr.RemovePlayerFromGroup(playerID, "vip")
+	if err != nil {
+		t.Fatalf("Failed to remove player from group: %v", err)
+	}
+
+	// Check permission is gone
+	if mgr.HasPermission(playerID, "chat.color") {
+		t.Error("Player should not have group permission after removal")
+	}
+
+	// Try to remove from non-existent group membership
+	err = mgr.RemovePlayerFromGroup(playerID, "vip")
+	if err == nil {
+		t.Error("Should fail when removing player from group they're not in")
+	}
+}
+
+func TestPermissionManager_PlayerPermissions(t *testing.T) {
+	defer cleanupPublicTest()
+	mgr := createTestPermissionManager()
+	playerID := uuid.New()
+
+	// Add player to ensure they exist
+	err := mgr.AddPlayerToGroup(playerID, "TestPlayer", "default")
+	if err != nil {
+		t.Fatalf("Failed to add player to default group: %v", err)
+	}
+
+	// Add individual permission
+	err = mgr.AddPlayerPermission(playerID, "custom.permission")
+	if err != nil {
+		t.Fatalf("Failed to add player permission: %v", err)
+	}
+
+	// Check permission
+	if !mgr.HasPermission(playerID, "custom.permission") {
+		t.Error("Player should have the added permission")
+	}
+
+	// Remove permission
+	err = mgr.RemovePlayerPermission(playerID, "custom.permission")
+	if err != nil {
+		t.Fatalf("Failed to remove player permission: %v", err)
+	}
+
+	// Check permission is gone
+	if mgr.HasPermission(playerID, "custom.permission") {
+		t.Error("Player should not have the removed permission")
+	}
+
+	// Try to remove non-existent permission
+	err = mgr.RemovePlayerPermission(playerID, "non.existent")
+	if err != ErrPermissionNotFound {
+		t.Errorf("Expected ErrPermissionNotFound, got %v", err)
+	}
+}
+
+func TestPermissionManager_ErrorConversion(t *testing.T) {
+	defer cleanupPublicTest()
+	mgr := createTestPermissionManager()
+	playerID := uuid.New()
+
+	// Test player not found error
+	err := mgr.AddPlayerPermission(playerID, "test.permission")
+	if err != ErrPlayerNotFound {
+		t.Errorf("Expected ErrPlayerNotFound, got %v", err)
+	}
+
+	// Test group not found error
+	err = mgr.AddPlayerToGroup(playerID, "TestPlayer", "non-existent")
+	if err != ErrGroupNotFound {
+		t.Errorf("Expected ErrGroupNotFound, got %v", err)
+	}
+}
+
+func TestPermissionManager_Save(t *testing.T) {
+	defer cleanupPublicTest()
+	mgr := createTestPermissionManager()
+
+	// Save should work without error
+	err := mgr.Save()
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Check that file was created
+	if _, err := os.Stat("/tmp/test_permission_public.json"); os.IsNotExist(err) {
+		t.Error("Save should create the storage file")
+	}
+}

--- a/permission_test.go
+++ b/permission_test.go
@@ -184,6 +184,68 @@ func TestPermissionManager_ErrorConversion(t *testing.T) {
 	}
 }
 
+func TestPermissionManager_GroupPermissionManagement(t *testing.T) {
+	defer cleanupPublicTest()
+	mgr := createTestPermissionManager()
+	playerID := uuid.New()
+
+	// Create a test group
+	err := mgr.CreateGroup("testers", []string{"test.basic"})
+	if err != nil {
+		t.Fatalf("Failed to create group: %v", err)
+	}
+
+	// Add player to group
+	err = mgr.AddPlayerToGroup(playerID, "TestPlayer", "testers")
+	if err != nil {
+		t.Fatalf("Failed to add player to group: %v", err)
+	}
+
+	// Add permission to group
+	err = mgr.AddPermissionToGroup("testers", "test.advanced")
+	if err != nil {
+		t.Fatalf("Failed to add permission to group: %v", err)
+	}
+
+	// Check that player now has the new permission
+	if !mgr.HasPermission(playerID, "test.advanced") {
+		t.Error("Player should have permission added to their group")
+	}
+
+	// Check that player still has original permission
+	if !mgr.HasPermission(playerID, "test.basic") {
+		t.Error("Player should still have original group permission")
+	}
+
+	// Remove permission from group
+	err = mgr.RemovePermissionFromGroup("testers", "test.advanced")
+	if err != nil {
+		t.Fatalf("Failed to remove permission from group: %v", err)
+	}
+
+	// Check that player no longer has the removed permission
+	if mgr.HasPermission(playerID, "test.advanced") {
+		t.Error("Player should not have permission removed from their group")
+	}
+
+	// Check that player still has original permission
+	if !mgr.HasPermission(playerID, "test.basic") {
+		t.Error("Player should still have original group permission")
+	}
+
+	// Try to add permission to non-existent group
+	err = mgr.AddPermissionToGroup("non-existent", "some.permission")
+	if err != ErrGroupNotFound {
+		t.Errorf("Expected ErrGroupNotFound, got %v", err)
+	}
+
+	// Try to remove permission that group doesn't have
+	err = mgr.RemovePermissionFromGroup("testers", "non.existent")
+	if err != ErrPermissionNotFound {
+		t.Errorf("Expected ErrPermissionNotFound, got %v", err)
+	}
+}
+
 func TestPermissionManager_Save(t *testing.T) {
 	defer cleanupPublicTest()
 	mgr := createTestPermissionManager()

--- a/permission_test.go
+++ b/permission_test.go
@@ -246,6 +246,92 @@ func TestPermissionManager_GroupPermissionManagement(t *testing.T) {
 	}
 }
 
+func TestPermissionManager_UpdateGroup(t *testing.T) {
+	defer cleanupPublicTest()
+	mgr := createTestPermissionManager()
+	playerID := uuid.New()
+
+	// Create a test group
+	err := mgr.CreateGroup("testers", []string{"test.basic", "test.intermediate"})
+	if err != nil {
+		t.Fatalf("Failed to create group: %v", err)
+	}
+
+	// Add player to group
+	err = mgr.AddPlayerToGroup(playerID, "TestPlayer", "testers")
+	if err != nil {
+		t.Fatalf("Failed to add player to group: %v", err)
+	}
+
+	// Check initial permissions
+	if !mgr.HasPermission(playerID, "test.basic") {
+		t.Error("Player should have test.basic permission from group")
+	}
+	if !mgr.HasPermission(playerID, "test.intermediate") {
+		t.Error("Player should have test.intermediate permission from group")
+	}
+
+	// Update group with new permissions
+	newPermissions := []string{"test.advanced", "test.expert"}
+	err = mgr.UpdateGroup("testers", newPermissions)
+	if err != nil {
+		t.Fatalf("Failed to update group: %v", err)
+	}
+
+	// Check that old permissions are gone
+	if mgr.HasPermission(playerID, "test.basic") {
+		t.Error("Player should not have old permission test.basic after group update")
+	}
+	if mgr.HasPermission(playerID, "test.intermediate") {
+		t.Error("Player should not have old permission test.intermediate after group update")
+	}
+
+	// Check that new permissions exist
+	if !mgr.HasPermission(playerID, "test.advanced") {
+		t.Error("Player should have new permission test.advanced from updated group")
+	}
+	if !mgr.HasPermission(playerID, "test.expert") {
+		t.Error("Player should have new permission test.expert from updated group")
+	}
+
+	// Update group with empty permissions
+	err = mgr.UpdateGroup("testers", []string{})
+	if err != nil {
+		t.Fatalf("Failed to update group with empty permissions: %v", err)
+	}
+
+	// Check that all permissions are gone
+	if mgr.HasPermission(playerID, "test.advanced") {
+		t.Error("Player should not have test.advanced after group cleared")
+	}
+	if mgr.HasPermission(playerID, "test.expert") {
+		t.Error("Player should not have test.expert after group cleared")
+	}
+
+	// Try to update non-existent group
+	err = mgr.UpdateGroup("non-existent", []string{"some.permission"})
+	if err != ErrGroupNotFound {
+		t.Errorf("Expected ErrGroupNotFound for non-existent group, got %v", err)
+	}
+
+	// Try to update system group (should allow it)
+	err = mgr.UpdateGroup("admin", []string{"custom.admin"})
+	if err != nil {
+		t.Errorf("Should be able to update admin group, got %v", err)
+	}
+
+	// Verify admin group update worked
+	adminPlayerID := uuid.New()
+	err = mgr.AddPlayerToGroup(adminPlayerID, "AdminPlayer", "admin")
+	if err != nil {
+		t.Fatalf("Failed to add player to admin group: %v", err)
+	}
+
+	if !mgr.HasPermission(adminPlayerID, "custom.admin") {
+		t.Error("Admin player should have custom.admin permission")
+	}
+}
+
 func TestPermissionManager_SetGetPlayerPermissions(t *testing.T) {
 	defer cleanupPublicTest()
 	mgr := createTestPermissionManager()

--- a/types.go
+++ b/types.go
@@ -1,25 +1,10 @@
 package dfpermission
 
-import (
-	"time"
+import "github.com/skuralll/df-permission/internal/shared"
+
+// Re-export configuration types from internal/shared for public API
+type (
+	StorageConfig = shared.StorageConfig
+	CacheConfig   = shared.CacheConfig
+	ManagerConfig = shared.ManagerConfig
 )
-
-// ストレージファイルの設定
-type StorageConfig struct {
-	// 保存するファイルのパス
-	Path string
-}
-
-// キャッシュの設定
-type CacheConfig struct {
-	TTL             time.Duration
-	CleanupInterval time.Duration
-	Enabled         bool
-}
-
-// PermissionServiceの設定
-type ManagerConfig struct {
-	AutoSave bool
-	Storage  StorageConfig
-	Cache    CacheConfig
-}

--- a/types.go
+++ b/types.go
@@ -2,7 +2,7 @@ package dfpermission
 
 import "github.com/skuralll/df-permission/internal/shared"
 
-// Re-export configuration types from internal/shared for public API
+// 公開API用にinternal/sharedから設定型を再エクスポート
 type (
 	StorageConfig = shared.StorageConfig
 	CacheConfig   = shared.CacheConfig


### PR DESCRIPTION
Add public API layer with wrapper pattern:
- Add PermissionManager interface with 8 core methods
- Add permissionManager wrapper struct for internal.Manager
- Add NewManager() factory function with wrapper implementation
- Add comprehensive error conversion with 6 public error types
- Add type re-exports to avoid import cycles

Refactor internal dependencies:
- Move config types to internal/shared to prevent import cycles
- Update all internal packages to use shared types
- Fix import cycles in domain, repository, and application layers
- Update all test files to use correct import paths

Features:
- Clean separation of public and internal APIs
- Stable public interface with error conversion
- Full backward compatibility with internal implementation
- Comprehensive test coverage for public API (7 test cases)
- All internal tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)